### PR TITLE
Avoid LocationScale

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,5 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v1
-        with:
-          cache-registries: "true"
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@v1

--- a/src/PowerAnalyses.jl
+++ b/src/PowerAnalyses.jl
@@ -1,7 +1,6 @@
 module PowerAnalyses
 
 using Distributions:
-    LocationScale,
     NoncentralChisq,
     NoncentralF,
     NoncentralT,

--- a/src/power.jl
+++ b/src/power.jl
@@ -88,7 +88,7 @@ end
 function _alternative_distribution(T::ConstantVarianceChisqTest, v, es, n)
     D = _distribution(T)
     d1 = D(v..., 0)
-    d2 = LocationScale(v, es, d1)
+    d2 = v + es * d1
     return d2
 end
 


### PR DESCRIPTION
Using the syntactic sugar should be more quick and also avoids the deprecations from https://github.com/JuliaStats/Distributions.jl/pull/1453.