### PR TITLE
use bracketing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerAnalyses"
 uuid = "fee4b835-1841-44f8-82ea-42813857171a"
 authors = ["Rik Huijzer <project.toml@huijzer.xyz>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/power.jl
+++ b/src/power.jl
@@ -123,7 +123,7 @@ Return the minimum effect size for some test `T` with significance level `alpha`
 """
 function get_es(T::StatisticalTest; alpha::Real, power::Real, n)
     f(es) = get_alpha(T; es, power, n) - alpha
-    initial_value = 0.5
+    initial_value = (0, 10)
     return find_zero(f, initial_value)
 end
 
@@ -134,6 +134,6 @@ Return minimum sample size `n` for some test `T` with significance level `alpha`
 """
 function get_n(T::StatisticalTest; alpha::Real, power::Real, es::Real)
     f(n) = get_alpha(T; es, power, n) - alpha
-    initial_value = 50
+    initial_value = (2, 1000)
     return find_zero(f, initial_value)
 end


### PR DESCRIPTION
This PR uses a bracketing algorithm for `find_zero`, as the initial point approach doesn't seem as robust. I didn't give much thought to the ranges specified and am assuming some monotonicity in the two underlying functions, so bracketing should work as desired.