### PR TITLE
disambiguate OneSampleTTest

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,15 @@
 name = "PowerAnalyses"
 uuid = "fee4b835-1841-44f8-82ea-42813857171a"
 authors = ["Rik Huijzer <project.toml@huijzer.xyz>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
 Distributions = "0.25"
+HypothesisTests = "0.10"
 Roots = "1, 2"
 julia = "1.6"

--- a/src/PowerAnalyses.jl
+++ b/src/PowerAnalyses.jl
@@ -7,6 +7,9 @@ using Distributions:
     UnivariateDistribution,
     cdf,
     quantile
+using HypothesisTests:
+    OneSampleTTest
+
 using Roots: find_zero
 
 include("types.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,13 +32,14 @@ Tests based around the Student's t-distribution.
 abstract type TTest <: StatisticalTest end
 
 """
-    OneSampleTTest(tail::Tail) <: TTest
+    _OneSampleTTest(tail::Tail) <: TTest
 
 Test whether the sample differs from a constant.
 """
-struct OneSampleTTest <: TTest
+struct _OneSampleTTest <: TTest
     tail::Tail
 end
+OneSampleTTest(tail::Tail) = _OneSampleTTest(tail)
 
 """
     IndependentSamplesTTest(tail::Tail) <: TTest
@@ -166,4 +167,3 @@ The effect size is the variance `ratio` and defined as `ratio = σ² / c`.
 struct ConstantVarianceChisqTest <: ChisqTest
     tail::Tail
 end
-


### PR DESCRIPTION
This PR simply avoids the name collision between `HypothesisTests.OneSampleTTest` and `PowerAnalyses.OneSampleTTest`. That was the only conflict I found.